### PR TITLE
Remove manual division indication

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,12 @@ The program accepts a few program arguments:
 --world-port=...       the port on which the application tries to connect to the RoboTeam World Observer to [default = 5558]
 --gc-ip=...            the IP on which the application tries to connect to the Game Controller [default = 127.0.0.1]
 --gc-port=...          the port on which the application tries to connect to the Game Controller [default = 10007]
---division=[A|B]       the division of the match that should be set when the application starts [default = B]
 --active               if the application should start in active mode instead of passive [default = passive]
 ```
 
 When running using gradle, these arguments can be specified in the following way:
 ```bash
-./gradlew run --args="--active --division=A"
+./gradlew run --args="--active"
 ```
 
 ## Rules

--- a/src/main/java/nl/roboteamtwente/autoref/SSLAutoRef.java
+++ b/src/main/java/nl/roboteamtwente/autoref/SSLAutoRef.java
@@ -15,7 +15,6 @@ public class SSLAutoRef {
     private static final float BALL_TOUCHING_DISTANCE = 0.025f;
 
     private final Referee referee;
-    private Division division = Division.B;
 
     private Thread worldThread;
     private GameControllerConnection gcConnection;
@@ -45,8 +44,6 @@ public class SSLAutoRef {
             referee.getGame().setPrevious(null);
             game.setPrevious(referee.getGame());
         }
-
-        game.setDivision(division);
 
         WorldOuterClass.World world = statePacket.getCommandExtrapolatedWorld();
 
@@ -452,13 +449,5 @@ public class SSLAutoRef {
 
     public boolean isGCConnected() {
         return gcConnection.isConnected();
-    }
-
-    public Division getDivision() {
-        return division;
-    }
-
-    public void setDivision(Division division) {
-        this.division = division;
     }
 }

--- a/src/main/java/nl/roboteamtwente/autoref/SSLAutoRef.java
+++ b/src/main/java/nl/roboteamtwente/autoref/SSLAutoRef.java
@@ -243,6 +243,8 @@ public class SSLAutoRef {
         game.getField().getSize().setY(statePacket.getField().getField().getFieldWidth() / 1000.0f);
         game.getField().getPosition().setX(-statePacket.getField().getField().getFieldLength() / 2.0f / 1000.0f);
         game.getField().getPosition().setY(-statePacket.getField().getField().getFieldWidth() / 2.0f / 1000.0f);
+        game.getField().getGoal().setWidth(statePacket.getField().getField().getGoalWidth() / 1000.0f);
+        game.getField().getGoal().setDepth(statePacket.getField().getField().getGoalDepth() / 1000.0f);
 
         for (SslVisionGeometry.SSL_FieldLineSegment lineSegment : statePacket.getField().getField().getFieldLinesList()) {
             Vector2 p1 = new Vector2(lineSegment.getP1().getX() / 1000.0f, lineSegment.getP1().getY() / 1000.0f);

--- a/src/main/java/nl/roboteamtwente/autoref/model/Division.java
+++ b/src/main/java/nl/roboteamtwente/autoref/model/Division.java
@@ -1,5 +1,0 @@
-package nl.roboteamtwente.autoref.model;
-
-public enum Division {
-    A, B
-}

--- a/src/main/java/nl/roboteamtwente/autoref/model/Field.java
+++ b/src/main/java/nl/roboteamtwente/autoref/model/Field.java
@@ -11,6 +11,7 @@ import java.util.Map;
 public class Field {
     private final Vector2 position;
     private final Vector2 size;
+    private final Goal goal;
 
     private float boundaryWidth;
 
@@ -24,6 +25,7 @@ public class Field {
         this.position = new Vector2(0, 0);
         this.size = new Vector2(0, 0);
         this.boundaryWidth = 0.0f;
+        this.goal = new Goal();
 
         this.lines = new HashMap<>();
     }
@@ -42,6 +44,10 @@ public class Field {
 
     public void setBoundaryWidth(float boundaryWidth) {
         this.boundaryWidth = boundaryWidth;
+    }
+
+    public Goal getGoal() {
+        return goal;
     }
 
     public Collection<FieldLine> getLines() {

--- a/src/main/java/nl/roboteamtwente/autoref/model/Game.java
+++ b/src/main/java/nl/roboteamtwente/autoref/model/Game.java
@@ -67,8 +67,6 @@ public class Game {
 
     private boolean forceStarted;
 
-    private Division division;
-
     public Game() {
         this.robots = new ArrayList<>();
         this.ball = new Ball();
@@ -87,7 +85,6 @@ public class Game {
         this.touches = new ArrayList<>();
 
         this.forceStarted = false;
-        this.division = Division.B;
     }
 
     /**
@@ -264,11 +261,4 @@ public class Game {
         return getState() == GameState.RUN || (getState() == GameState.PENALTY && getKickIntoPlay() != null);
     }
 
-    public Division getDivision() {
-        return division;
-    }
-
-    public void setDivision(Division division) {
-        this.division = division;
-    }
 }

--- a/src/main/java/nl/roboteamtwente/autoref/model/Goal.java
+++ b/src/main/java/nl/roboteamtwente/autoref/model/Goal.java
@@ -1,0 +1,31 @@
+package nl.roboteamtwente.autoref.model;
+
+/**
+ * A class which is used to create the Goal object of the game.
+ */
+public class Goal {
+
+    private float width;
+    private float depth;
+
+    public Goal() {
+        this.width = 0.0f;
+        this.depth = 0.0f;
+    }
+
+    public float getWidth() {
+        return width;
+    }
+
+    public void setWidth(float width) {
+        this.width = width;
+    }
+
+    public float getDepth() {
+        return depth;
+    }
+
+    public void setDepth(float depth) {
+        this.depth = depth;
+    }
+}

--- a/src/main/java/nl/roboteamtwente/autoref/ui/AutoRefController.java
+++ b/src/main/java/nl/roboteamtwente/autoref/ui/AutoRefController.java
@@ -13,7 +13,6 @@ import javafx.scene.paint.Color;
 import javafx.scene.text.Text;
 import javafx.scene.text.TextFlow;
 import nl.roboteamtwente.autoref.SSLAutoRef;
-import nl.roboteamtwente.autoref.model.Division;
 
 import java.net.URL;
 import java.util.Objects;
@@ -24,9 +23,6 @@ public class AutoRefController implements Initializable {
 
     @FXML
     public ComboBox<String> modeBox;
-
-    @FXML
-    public ComboBox<String> divisionBox;
 
     @FXML
     public ListView<TextFlow> logList;
@@ -63,14 +59,9 @@ public class AutoRefController implements Initializable {
         });
 
         modeBox.getItems().addAll("Passive", "Active");
-        divisionBox.getItems().addAll("A", "B");
 
         modeBox.setOnAction((event) -> {
             sslAutoRef.setActive(Objects.equals(modeBox.getValue(), "Active"));
-        });
-
-        divisionBox.setOnAction((event) -> {
-            sslAutoRef.setDivision(Objects.equals(divisionBox.getValue(), "A") ? Division.A : Division.B);
         });
 
         clearButton.setOnAction((event) -> {
@@ -95,24 +86,10 @@ public class AutoRefController implements Initializable {
             int portGameController = Integer.parseInt(parameters.getNamed().getOrDefault("gc-port", "10007"));
 
             boolean active = parameters.getUnnamed().contains("--active");
-            String divisionString = parameters.getNamed().getOrDefault("division", "B").toLowerCase();
-
-            Division division;
-            if (divisionString.equals("a")) {
-                division = Division.A;
-            } else if (divisionString.equals("b")) {
-                division = Division.B;
-            } else {
-                System.err.println("Unknown division " + divisionString);
-                System.exit(1);
-                return;
-            }
 
             modeBox.setValue(active ? "Active" : "Passive");
-            divisionBox.setValue(division.toString());
 
             sslAutoRef.setActive(active);
-            sslAutoRef.setDivision(division);
             sslAutoRef.start(ipWorld, ipGameController, portWorld, portGameController);
         } catch (NumberFormatException e) {
             System.err.println("Failed to parse port program argument.");

--- a/src/main/java/nl/roboteamtwente/autoref/validators/AimlessKickValidator.java
+++ b/src/main/java/nl/roboteamtwente/autoref/validators/AimlessKickValidator.java
@@ -61,7 +61,7 @@ public class AimlessKickValidator implements RuleValidator {
 
     @Override
     public boolean isActive(Game game) {
-        return game.isBallInPlay() && game.getDivision() == Division.B;
+        return game.isBallInPlay();
     }
 
 

--- a/src/main/java/nl/roboteamtwente/autoref/validators/PossibleGoalValidator.java
+++ b/src/main/java/nl/roboteamtwente/autoref/validators/PossibleGoalValidator.java
@@ -15,21 +15,14 @@ public class PossibleGoalValidator implements RuleValidator {
     /**
      * Check if the ball position is inside the goal post
      * Division A and B have different goal size
-     * @param game
+     * @param game - the game that is currently taking place
      * @param side - the side of the ball when enter the goal
      * @param ballPos - the position of the ball
      * @return true if ball is inside the goal otherwise false
      */
     boolean checkBallInsideGoal(Game game, Side side, Vector2 ballPos) {
-        float goalDepthLength = 0.18f;
-        float goalWidthLength;
-
-        // Division A and B have different goal size
-        if (game.getDivision() == Division.A) {
-            goalWidthLength = 1.8f;
-        } else {
-            goalWidthLength = 1f;
-        }
+        float goalDepthLength = game.getField().getGoal().getDepth();
+        float goalWidthLength = game.getField().getGoal().getWidth();
 
         String fieldLineName;
         if (side.equals(Side.RIGHT)) {

--- a/src/main/resources/auto_ref.fxml
+++ b/src/main/resources/auto_ref.fxml
@@ -21,14 +21,9 @@
     </VBox>
     <VBox prefHeight="200.0" prefWidth="100.0">
         <HBox>
-            <HBox alignment="CENTER_LEFT">
+            <HBox alignment="CENTER_RIGHT">
                 <Label text="AutoRef mode: "/>
                 <ComboBox fx:id="modeBox" prefWidth="150.0"/>
-            </HBox>
-            <Region HBox.hgrow="ALWAYS" />
-            <HBox alignment="CENTER_RIGHT">
-                <Label text="Division: "/>
-                <ComboBox fx:id="divisionBox" prefWidth="100.0"/>
             </HBox>
             <padding>
                 <Insets bottom="5.0" left="5.0" right="5.0" top="5.0"/>


### PR DESCRIPTION
There is no need to manually tell the autoref which division is playing, since it is handled by the game controller.